### PR TITLE
Allow post step callbacks to be added to a space instance.

### DIFF
--- a/cymunk/space.pxi
+++ b/cymunk/space.pxi
@@ -475,8 +475,8 @@ cdef class Space:
         the collisions in the usual case.
         '''
         cpSpaceStep(self._space, dt)
-        for obj, (func, args, kwargs) in self._post_step_callbacks.items():
-            func(obj, *args, **kwargs)
+        for key in self._post_step_callbacks:
+            self._post_step_callbacks[key](self)  
         self._post_step_callbacks = {}
 
     def register_bb_query_func(self, func):
@@ -567,3 +567,12 @@ cdef class Space:
     def UseSpatialHash(self, cpFloat dim, int count):
         cpSpaceUseSpatialHash(self._space, dim, count)
 
+    def add_post_step_callback(self, callback_function, key, *args, **kwargs):
+        if key in self._post_step_callbacks:
+            return False
+
+        def f(x):
+            callback_function(self, key, *args, **kwargs)
+
+        self._post_step_callbacks[key] = f
+        return True

--- a/cymunk/space.pxi
+++ b/cymunk/space.pxi
@@ -475,8 +475,8 @@ cdef class Space:
         the collisions in the usual case.
         '''
         cpSpaceStep(self._space, dt)
-        for key in self._post_step_callbacks:
-            self._post_step_callbacks[key](self)  
+        for _, callback in self._post_step_callbacks.items():
+            callback(self)
         self._post_step_callbacks = {}
 
     def register_bb_query_func(self, func):


### PR DESCRIPTION
I was looking for a way to add "post step" callbacks to the space instance. I decided to add the "add_post_step_callback" method in the Space class as a way to register callbacks in the "_post_step_callbacks" dict attribute. The implementation was actually taken from pymunk.