### PR TITLE
Fixed Arbiter contacts getter

### DIFF
--- a/cymunk/core.pxi
+++ b/cymunk/core.pxi
@@ -668,7 +668,7 @@ cdef class Arbiter:
                         Vec2d(point.x, point.y),
                         Vec2d(normal.x, normal.y),
                         cpArbiterGetDepth(self._arbiter, i)))
-                return self._contacts
+            return self._contacts
 
     property shapes:
         '''


### PR DESCRIPTION
The `Arbiter` contacts property returned None after the the first call as the cached contacts weren't returned properly.

Easy to reproduce:
```
def pre_solve_func(self, space, arbiter):
    print "contacts 1:", arbiter.contacts
    print "contacts 2:", arbiter.contacts
```

**Before:**
```
contacts 1: [Contact(<cymunk.Vec2d x=477.942200 y=8.509947>, <cymunk.Vec2d x=0.000000 y=-1.000000>, -2.980105400085449)]
contacts 2: None
```

**Now:**
```
contacts 1: [Contact(<cymunk.Vec2d x=477.942200 y=8.509947>, <cymunk.Vec2d x=0.000000 y=-1.000000>, -2.980105400085449)]
contacts 2: [Contact(<cymunk.Vec2d x=477.942200 y=8.509947>, <cymunk.Vec2d x=0.000000 y=-1.000000>, -2.980105400085449)]
```